### PR TITLE
测试是否可行

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,8 +55,8 @@ def get_settings():
         proxies_set = fp.read()
     if proxies_set:
         proxies = {
-            'http': proxies_set,
-            'https': proxies_set
+            'http': 'http://'+proxies_set,
+            'https': 'http://'+proxies_set
         }
     # *检测是否有此目录，没有就创建
     if not os.path.exists("%s/" % download_path):


### PR DESCRIPTION
解决方法：#8
总体来说，是因为clash的代理问题导致urllib代理无法知道是否走了ssl导致直接ip+端口走ssl
此问题应该可以依照此链接进行解决[clash_for_windows_pkg #1787](https://github.com/Fndroid/clash_for_windows_pkg/issues/1787)